### PR TITLE
Use `cat` instead of `more`

### DIFF
--- a/cmd/gwvault/main.go
+++ b/cmd/gwvault/main.go
@@ -452,8 +452,8 @@ func main() {
 						return cli.NewExitError(err, 1)
 					}
 
-					// Open 'more' stream of contents
-					cmd := exec.Command("more", tempFile.Name())
+					// Open 'cat' stream of contents
+					cmd := exec.Command("cat", tempFile.Name())
 					cmd.Stdout = os.Stdout
 					cmd.Stdin = os.Stdin
 					cmd.Stderr = os.Stderr


### PR DESCRIPTION
using `more` every time breaks any data processing while in a non-interactive shell. `more` prefixes the contents with a header containing the filename when `stdin` is not aTTY. Piping the output to something like `yq` results in an error

Steps to reproduce the bug

```
gwvault --vault-password-file=./my-password some_vault.yml </dev/null
```